### PR TITLE
Variable and changing support

### DIFF
--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/NoneValue.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/NoneValue.java
@@ -23,13 +23,18 @@ public final class NoneValue extends SkriptValue {
 		return INSTANCE;
 	}
 
+	@Override
+	public String toString() {
+		return "<none>";
+	}
+
 	/**
 	 * A Skript value type representing {@code <none>}.
 	 */
 	public static final class Type extends SkriptValueTypeBase<NoneValue> {
 		private final SkriptProperty<NoneValue, NoneValue> property = new PropagatingProperty(runtime());
 
-		public Type(SkriptRuntime runtime, SkriptValueType<?> superType) {
+		public Type(SkriptRuntime runtime, SkriptValueType<? super NoneValue> superType) {
 			super(runtime, NoneValue.class, superType, Map.of());
 		}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptProperty.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptProperty.java
@@ -42,6 +42,7 @@ public interface SkriptProperty<TReceiver extends SkriptValue, TValue extends Sk
 	 * Adds a value to the value of this property on the given receiver.
 	 * <p>
 	 * The default implementation is a no-op meaning this property doesn't support adding any type.
+	 * TODO: invalid docs ^
 	 * @param receiver The receiver to add the value to.
 	 * @param value The value to add.
 	 * @return Whether the value was added.
@@ -64,6 +65,7 @@ public interface SkriptProperty<TReceiver extends SkriptValue, TValue extends Sk
 	 * Removes a value from the value of this property on the given receiver.
 	 * <p>
 	 * The default implementation is a no-op meaning this property doesn't support removing any type.
+	 * TODO: invalid docs ^
 	 * @param receiver The receiver to remove the value from.
 	 * @param value The value to remove.
 	 * @return Whether the value was removed.

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptValueType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptValueType.java
@@ -66,7 +66,7 @@ public interface SkriptValueType<T extends SkriptValue> {
 	 * @param name the name of the property
 	 * @return the property, or null if not found
 	 */
-	@Nullable SkriptProperty<T, ?> getProperty(String name);
+	@Nullable SkriptProperty<? super T, ?> getProperty(String name);
 
 	/**
 	 * Get the JVM class that this type represents.

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/base/SkriptValueTypeBase.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/base/SkriptValueTypeBase.java
@@ -17,14 +17,14 @@ import java.util.Map;
 public class SkriptValueTypeBase<T extends SkriptValue> implements SkriptValueType<T> {
 	private final @NotNull SkriptRuntime runtime;
 	private final Class<T> valueClass;
-	private final SkriptValueType<?> superType;
+	private final SkriptValueType<? super T> superType;
 
 	private final Map<String, SkriptProperty<T, ?>> properties;
 
 	public SkriptValueTypeBase(
 		@NotNull SkriptRuntime runtime,
 		@NotNull Class<T> valueClass,
-		@Nullable SkriptValueType<?> superType,
+		@Nullable SkriptValueType<? super T> superType,
 		@NotNull Map<String, SkriptProperty<T, ?>> properties
 	) {
 		this.runtime = runtime;
@@ -57,12 +57,13 @@ public class SkriptValueTypeBase<T extends SkriptValue> implements SkriptValueTy
 
 	@Override
 	public boolean hasProperty(String name) {
-		return properties.containsKey(name);
+		return properties.containsKey(name) || (superType != null && superType.hasProperty(name));
 	}
 
 	@Override
-	public @Nullable SkriptProperty<T, ?> getProperty(String name) {
-		return properties.get(name);
+	public @Nullable SkriptProperty<? super T, ?> getProperty(String name) {
+		if (properties.containsKey(name)) return properties.get(name);
+		return superType != null ? superType.getProperty(name) : null;
 	}
 
 	@Override

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/util/TypeOperationUtils.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/util/TypeOperationUtils.java
@@ -1,0 +1,119 @@
+package org.skriptlang.skript.api.util;
+
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.api.types.SkriptValue;
+import org.skriptlang.skript.api.types.SkriptValueOrVariable;
+import org.skriptlang.skript.api.types.Variable;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Utilities for properly interacting with types,
+ * especially in the case of properly performing operations on SkriptValueOrVariables.
+ */
+public final class TypeOperationUtils {
+	private TypeOperationUtils() {
+		// no instance
+	}
+
+	/**
+	 * Applies a change to the given receiver, using the given value and changer functions that are present on the type.
+	 * @param receiver The receiver to apply the change to.
+	 * @param value The value to apply to the receiver.
+	 * @param variableChanger The variable's changer which will decide how to change the receiver.
+	 * @param mutatingChanger The mutating changer which will mutate the receiver.
+	 * @return Whether the change was applied.
+	 */
+	public static boolean applyChange(
+		SkriptValueOrVariable receiver,
+		SkriptValue value,
+		BiFunction<Variable, SkriptValue, Boolean> variableChanger,
+		BiFunction<SkriptValue, SkriptValue, Boolean> mutatingChanger
+	) {
+		if (receiver instanceof SkriptValue receiverAsValue) {
+			// mutating changer is the only way to change this receiver
+			return mutatingChanger.apply(receiverAsValue, value);
+		} else if (receiver instanceof Variable receiverAsVariable) {
+			return variableChanger.apply(receiverAsVariable, value);
+		}
+		// we don't know how to change this receiver -
+		// someone probably implemented the union type when they shouldn't have
+		return false;
+	}
+
+	/**
+	 * Adds the given value to the receiver.
+	 * @param receiver The receiver to add the value to.
+	 * @param value The value to add.
+	 * @return Whether the value was added.
+	 */
+	public static boolean applyAdd(
+		SkriptValueOrVariable receiver,
+		SkriptValue value
+	) {
+		return applyChange(receiver, value, Variable::add, SkriptValue::addDirectly);
+	}
+
+	/**
+	 * Removes the given value from the receiver.
+	 * @param receiver The receiver to remove the value from.
+	 * @param value The value to remove.
+	 * @return Whether the value was removed.
+	 */
+	public static boolean applyRemove(
+		SkriptValueOrVariable receiver,
+		SkriptValue value
+	) {
+		return applyChange(receiver, value, Variable::remove, SkriptValue::removeDirectly);
+	}
+
+	/**
+	 * Does simple logic for applying a change to a receiver that doesn't involve a value.
+	 * @param receiver The receiver to apply the change to.
+	 * @param variableChanger The variable's changer which will decide how to change the receiver.
+	 * @param mutatingChanger The mutating changer which will mutate the receiver.
+	 * @return Whether the change was applied.
+	 */
+	private static boolean applyChangeNoValue(
+		SkriptValueOrVariable receiver,
+		Function<Variable, Boolean> variableChanger,
+		Function<SkriptValue, Boolean> mutatingChanger
+	) {
+		if (receiver instanceof SkriptValue receiverAsValue) {
+			// mutating changer is the only way to change this receiver
+			return mutatingChanger.apply(receiverAsValue);
+		} else if (receiver instanceof Variable receiverAsVariable) {
+			return variableChanger.apply(receiverAsVariable);
+		}
+		// we don't know how to change this receiver -
+		// someone probably implemented the union type when they shouldn't have
+		return false;
+	}
+
+	/**
+	 * Increments the receiver.
+	 * @param receiver The receiver to increment.
+	 * @return Whether the receiver was incremented.
+	 */
+	public static boolean applyIncrement(
+		SkriptValueOrVariable receiver,
+		@Nullable SkriptValue value
+	) {
+		if (value != null) return applyAdd(receiver, value);
+		return applyChangeNoValue(receiver, Variable::increment, SkriptValue::incrementDirectly);
+	}
+
+	/**
+	 * Decrements the receiver.
+	 * @param receiver The receiver to decrement.
+	 * @return Whether the receiver was decremented.
+	 */
+	public static boolean applyDecrement(
+		SkriptValueOrVariable receiver,
+		@Nullable SkriptValue value
+	) {
+		if (value != null) return applyRemove(receiver, value);
+		return applyChangeNoValue(receiver, Variable::decrement, SkriptValue::decrementDirectly);
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/runtime/SkriptRuntimeImpl.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/runtime/SkriptRuntimeImpl.java
@@ -2,10 +2,6 @@ package org.skriptlang.skript.runtime;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.skriptlang.skript.api.nodes.SectionNode;
-import org.skriptlang.skript.api.nodes.StatementNode;
-import org.skriptlang.skript.api.nodes.StructureNode;
-import org.skriptlang.skript.api.nodes.SyntaxNode;
 import org.skriptlang.skript.api.runtime.ExecuteContext;
 import org.skriptlang.skript.api.runtime.SkriptRuntime;
 import org.skriptlang.skript.api.script.Script;
@@ -92,13 +88,13 @@ public class SkriptRuntimeImpl implements SkriptRuntime {
 		ExecuteContext scriptContext = new ScriptContext(this, script, globalContext());
 
 		ExecuteResult result = SectionUtils.loadStructuresIn(script.root(), scriptContext);
-		if (result instanceof ExecuteResult.Failure) return null;
 
 		synchronized (loadingScripts) {
-			loadedScripts.put(script, scriptContext);
+			if (result instanceof ExecuteResult.Success) loadedScripts.put(script, scriptContext);
 			loadingScripts.remove(script);
 		}
 
+		if (result instanceof ExecuteResult.Failure) return null;
 		return scriptContext;
 	}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
@@ -2,8 +2,12 @@ package org.skriptlang.skript.stdlib;
 
 import org.skriptlang.skript.api.SkriptParser;
 import org.skriptlang.skript.stdlib.syntax.effects.BroadcastEffect;
+import org.skriptlang.skript.stdlib.syntax.effects.IncrementEffect;
+import org.skriptlang.skript.stdlib.syntax.effects.SetEffect;
+import org.skriptlang.skript.stdlib.syntax.expressions.NumberLiteralExpression;
 import org.skriptlang.skript.stdlib.syntax.expressions.PropertyExpression;
 import org.skriptlang.skript.stdlib.syntax.expressions.StringLiteralExpression;
+import org.skriptlang.skript.stdlib.syntax.expressions.VariableExpression;
 import org.skriptlang.skript.stdlib.syntax.structures.CommandStructure;
 import org.skriptlang.skript.stdlib.syntax.structures.OnScriptLoadEvent;
 
@@ -17,9 +21,13 @@ public final class SyntaxManifest {
 		parser.submitNode(CommandStructure.TYPE);
 		parser.submitNode(BroadcastEffect.TYPE);
 		parser.submitNode(StringLiteralExpression.TYPE);
+		parser.submitNode(NumberLiteralExpression.TYPE);
 		parser.submitNode(PropertyExpression.TYPE);
 		parser.submitScope(OnScriptLoadEvent.SCOPE);
 		parser.submitNode(OnScriptLoadEvent.TYPE);
+		parser.submitNode(VariableExpression.TYPE);
+		parser.submitNode(SetEffect.TYPE);
+		parser.submitNode(IncrementEffect.TYPE);
 	}
 
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
@@ -1,9 +1,7 @@
 package org.skriptlang.skript.stdlib;
 
 import org.skriptlang.skript.api.SkriptParser;
-import org.skriptlang.skript.stdlib.syntax.effects.BroadcastEffect;
-import org.skriptlang.skript.stdlib.syntax.effects.IncrementEffect;
-import org.skriptlang.skript.stdlib.syntax.effects.SetEffect;
+import org.skriptlang.skript.stdlib.syntax.effects.*;
 import org.skriptlang.skript.stdlib.syntax.expressions.NumberLiteralExpression;
 import org.skriptlang.skript.stdlib.syntax.expressions.PropertyExpression;
 import org.skriptlang.skript.stdlib.syntax.expressions.StringLiteralExpression;
@@ -28,6 +26,9 @@ public final class SyntaxManifest {
 		parser.submitNode(VariableExpression.TYPE);
 		parser.submitNode(SetEffect.TYPE);
 		parser.submitNode(IncrementEffect.TYPE);
+		parser.submitNode(DecrementEffect.TYPE);
+		parser.submitNode(AddEffect.TYPE);
+		parser.submitNode(RemoveEffect.TYPE);
 	}
 
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/AddEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/AddEffect.java
@@ -1,0 +1,49 @@
+package org.skriptlang.skript.stdlib.syntax.effects;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.EffectNode;
+import org.skriptlang.skript.api.nodes.EffectNodeType;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.ErrorValue;
+import org.skriptlang.skript.api.util.ExecuteResult;
+import org.skriptlang.skript.api.util.TypeOperationUtils;
+
+import java.util.List;
+
+public class AddEffect implements EffectNode {
+	public static final EffectNodeType<AddEffect> TYPE = new EffectNodeType<>() {
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of(
+				"(add|give) <expr> to <expr>"
+			);
+		}
+
+		@Override
+		public @NotNull AddEffect create(@NotNull List<SyntaxNode> children) {
+			return new AddEffect(
+				(ExpressionNode<?>) children.get(0),
+				(ExpressionNode<?>) children.get(1)
+			);
+		}
+	};
+
+	private final ExpressionNode<?> valueSelector;
+	private final ExpressionNode<?> receiverSelector;
+
+	public AddEffect(ExpressionNode<?> valueSelector, ExpressionNode<?> receiverSelector) {
+		this.valueSelector = valueSelector;
+		this.receiverSelector = receiverSelector;
+	}
+
+	@Override
+	public @NotNull ExecuteResult execute(@NotNull ExecuteContext context) {
+
+		return TypeOperationUtils.applyAdd(receiverSelector.resolve(context), valueSelector.resolve(context).toValue())
+			? ExecuteResult.success()
+			: ExecuteResult.failure(new ErrorValue("Failed to add value to receiver - does it support adding?"));
+
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/DecrementEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/DecrementEffect.java
@@ -8,32 +8,29 @@ import org.skriptlang.skript.api.nodes.ExpressionNode;
 import org.skriptlang.skript.api.nodes.SyntaxNode;
 import org.skriptlang.skript.api.runtime.ExecuteContext;
 import org.skriptlang.skript.api.types.ErrorValue;
-import org.skriptlang.skript.api.types.SkriptValue;
-import org.skriptlang.skript.api.types.SkriptValueOrVariable;
-import org.skriptlang.skript.api.types.Variable;
 import org.skriptlang.skript.api.util.ExecuteResult;
 import org.skriptlang.skript.api.util.TypeOperationUtils;
 
 import java.util.List;
 
-public class IncrementEffect implements EffectNode {
-	public static final EffectNodeType<IncrementEffect> TYPE = new EffectNodeType<>() {
+public class DecrementEffect implements EffectNode {
+	public static final EffectNodeType<DecrementEffect> TYPE = new EffectNodeType<>() {
 		@Override
 		public List<String> getSyntaxes() {
-			return List.of("increment <expr> [by <expr>]");
+			return List.of("decrement <expr> [by <expr>]");
 		}
 
 		@Override
-		public @NotNull IncrementEffect create(List<SyntaxNode> children) {
+		public @NotNull DecrementEffect create(List<SyntaxNode> children) {
 			ExpressionNode<?> amountSelector = children.size() == 2 ? (ExpressionNode<?>) children.get(1) : null;
-			return new IncrementEffect((ExpressionNode<?>) children.getFirst(), amountSelector);
+			return new DecrementEffect((ExpressionNode<?>) children.getFirst(), amountSelector);
 		}
 	};
 
 	private final @NotNull ExpressionNode<?> receiverSelector;
 	private final @Nullable ExpressionNode<?> amountSelector;
 
-	public IncrementEffect(@NotNull ExpressionNode<?> receiverSelector, @Nullable ExpressionNode<?> amountSelector) {
+	public DecrementEffect(@NotNull ExpressionNode<?> receiverSelector, @Nullable ExpressionNode<?> amountSelector) {
 		this.receiverSelector = receiverSelector;
 		this.amountSelector = amountSelector;
 	}
@@ -41,9 +38,12 @@ public class IncrementEffect implements EffectNode {
 	@Override
 	public @NotNull ExecuteResult execute(@NotNull ExecuteContext context) {
 
-		return TypeOperationUtils.applyIncrement(receiverSelector.resolve(context), amountSelector == null ? null : amountSelector.resolve(context).toValue())
+		return TypeOperationUtils.applyDecrement(
+			receiverSelector.resolve(context),
+			amountSelector == null ? null : amountSelector.resolve(context).toValue()
+		)
 			? ExecuteResult.success()
-			: ExecuteResult.failure(new ErrorValue("Failed to increment value - does it support incrementing?"));
+			: ExecuteResult.failure(new ErrorValue("Failed to decrement value - does it support decrementing?"));
 
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/IncrementEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/IncrementEffect.java
@@ -1,0 +1,74 @@
+package org.skriptlang.skript.stdlib.syntax.effects;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.skriptlang.skript.api.nodes.EffectNode;
+import org.skriptlang.skript.api.nodes.EffectNodeType;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.ErrorValue;
+import org.skriptlang.skript.api.types.SkriptValue;
+import org.skriptlang.skript.api.types.SkriptValueOrVariable;
+import org.skriptlang.skript.api.types.Variable;
+import org.skriptlang.skript.api.util.ExecuteResult;
+
+import java.util.List;
+
+public class IncrementEffect implements EffectNode {
+	public static final EffectNodeType<IncrementEffect> TYPE = new EffectNodeType<>() {
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of("increment <expr> [by <expr>]");
+		}
+
+		@Override
+		public @NotNull IncrementEffect create(List<SyntaxNode> children) {
+			SyntaxNode amountSelector = children.size() == 2 ? children.get(1) : null;
+			return new IncrementEffect((ExpressionNode<?>) children.getFirst(), (ExpressionNode<?>) amountSelector);
+		}
+	};
+
+	private final @NotNull ExpressionNode<?> receiverSelector;
+	private final @Nullable ExpressionNode<?> amountSelector;
+
+	public IncrementEffect(@NotNull ExpressionNode<?> receiverSelector, @Nullable ExpressionNode<?> amountSelector) {
+		this.receiverSelector = receiverSelector;
+		this.amountSelector = amountSelector;
+	}
+
+	@Override
+	public @NotNull ExecuteResult execute(@NotNull ExecuteContext context) {
+		SkriptValueOrVariable receiver = receiverSelector.resolve(context);
+
+
+		if (amountSelector != null) {
+			SkriptValue amount = amountSelector.resolve(context).toValue();
+			if (receiver instanceof SkriptValue receiverValue) {
+				// if it's a value, still try adding directly
+				// possible with something like `increment thing by 1` where `thing` ends up being a simple value
+				if (!receiverValue.addDirectly(amount)) {
+					return ExecuteResult.failure(new ErrorValue(receiver + " does not support directly incrementing by an amount"));
+				}
+			} else if (receiver instanceof Variable receiverVariable) {
+				if (!receiverVariable.add(amount)) {
+					return ExecuteResult.failure(new ErrorValue(receiver + " does not support incrementing by an amount"));
+				}
+			}
+		} else {
+			if (receiver instanceof SkriptValue receiverValue) {
+				// if it's a value, still try adding directly
+				// possible with something like `increment thing` where `thing` ends up being a simple value
+				if (!receiverValue.incrementDirectly()) {
+					return ExecuteResult.failure(new ErrorValue(receiver + " does not support directly incrementing"));
+				}
+			} else if (receiver instanceof Variable receiverVariable) {
+				if (!receiverVariable.increment()) {
+					return ExecuteResult.failure(new ErrorValue(receiver + " does not support incrementing"));
+				}
+			}
+		}
+
+		return ExecuteResult.success();
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/RemoveEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/RemoveEffect.java
@@ -1,0 +1,47 @@
+package org.skriptlang.skript.stdlib.syntax.effects;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.EffectNode;
+import org.skriptlang.skript.api.nodes.EffectNodeType;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.ErrorValue;
+import org.skriptlang.skript.api.util.ExecuteResult;
+import org.skriptlang.skript.api.util.TypeOperationUtils;
+
+import java.util.List;
+
+public class RemoveEffect implements EffectNode {
+	public static final EffectNodeType<RemoveEffect> TYPE = new EffectNodeType<>() {
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of("remove <expr> from <expr>");
+		}
+
+		@Override
+		public @NotNull RemoveEffect create(@NotNull List<SyntaxNode> children) {
+			return new RemoveEffect(
+				(ExpressionNode<?>) children.get(0),
+				(ExpressionNode<?>) children.get(1)
+			);
+		}
+	};
+
+	private final ExpressionNode<?> valueSelector;
+	private final ExpressionNode<?> receiverSelector;
+
+	public RemoveEffect(ExpressionNode<?> valueSelector, ExpressionNode<?> receiverSelector) {
+		this.valueSelector = valueSelector;
+		this.receiverSelector = receiverSelector;
+	}
+
+	@Override
+	public @NotNull ExecuteResult execute(@NotNull ExecuteContext context) {
+
+		return TypeOperationUtils.applyRemove(receiverSelector.resolve(context), valueSelector.resolve(context).toValue())
+			? ExecuteResult.success()
+			: ExecuteResult.failure(new ErrorValue("Failed to remove value from receiver - does it support removing?"));
+
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/SetEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/SetEffect.java
@@ -1,0 +1,61 @@
+package org.skriptlang.skript.stdlib.syntax.effects;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.EffectNode;
+import org.skriptlang.skript.api.nodes.EffectNodeType;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.*;
+import org.skriptlang.skript.api.util.ExecuteResult;
+import org.skriptlang.skript.stdlib.syntax.expressions.VariableExpression;
+
+import java.util.List;
+
+public class SetEffect implements EffectNode {
+	public static final EffectNodeType<SetEffect> TYPE = new EffectNodeType<SetEffect>() {
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of("set <expr> to <expr>");
+		}
+
+		@Override
+		public @NotNull SetEffect create(List<SyntaxNode> children) {
+			return new SetEffect((ExpressionNode<?>) children.getFirst(), (ExpressionNode<?>) children.get(1));
+		}
+	};
+
+	private final ExpressionNode<?> receiverSelector;
+	private final ExpressionNode<?> valueSelector;
+
+	public SetEffect(ExpressionNode<?> receiverSelector, ExpressionNode<?> valueSelector) {
+		this.receiverSelector = receiverSelector;
+		this.valueSelector = valueSelector;
+	}
+
+	@Override
+	public @NotNull ExecuteResult execute(@NotNull ExecuteContext context) {
+		SkriptValueOrVariable receiver = receiverSelector.resolve(context);
+		Variable variable = null;
+		if (receiver instanceof NoneValue) {
+			if (receiverSelector instanceof VariableExpression varExpr) {
+				// this case covers a special case
+				// where a variable expression will return NoneValue because the variable is not set.
+				// since it's the set expression, we just create a new variable.
+				variable = context.setVariable(varExpr.name());
+			} else {
+				return ExecuteResult.failure(new ErrorValue("Cannot set <none> to a value"));
+			}
+		} else if (receiver instanceof Variable v) {
+			variable = v;
+		}
+
+		if (variable == null) return ExecuteResult.failure(new ErrorValue("Cannot set a value to a non-variable"));
+
+		SkriptValue value = valueSelector.resolve(context).toValue();
+
+		variable.set(value);
+
+		return ExecuteResult.success();
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/NumberLiteralExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/NumberLiteralExpression.java
@@ -1,0 +1,41 @@
+package org.skriptlang.skript.stdlib.syntax.expressions;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.ExpressionNodeType;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.nodes.TokenNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.NumberValue;
+
+import java.util.List;
+
+public class NumberLiteralExpression implements ExpressionNode<NumberValue> {
+	public static final ExpressionNodeType<NumberLiteralExpression, NumberValue> TYPE = new ExpressionNodeType<>() {
+		@Override
+		public Class<NumberValue> getReturnType() {
+			return NumberValue.class;
+		}
+
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of("<token::number>");
+		}
+
+		@Override
+		public @NotNull NumberLiteralExpression create(List<SyntaxNode> children) {
+			return new NumberLiteralExpression(new NumberValue(Double.parseDouble(((TokenNode) children.getFirst()).token().asString())));
+		}
+	};
+
+	private final NumberValue value;
+
+	public NumberLiteralExpression(NumberValue value) {
+		this.value = value;
+	}
+
+	@Override
+	public @NotNull NumberValue resolve(@NotNull ExecuteContext context) {
+		return value;
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/VariableExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/VariableExpression.java
@@ -1,0 +1,49 @@
+package org.skriptlang.skript.stdlib.syntax.expressions;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.ExpressionNodeType;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.nodes.TokenNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.NoneValue;
+import org.skriptlang.skript.api.types.SkriptValueOrVariable;
+
+import java.util.List;
+
+public class VariableExpression implements ExpressionNode<SkriptValueOrVariable> {
+	public static final ExpressionNodeType<VariableExpression, SkriptValueOrVariable> TYPE = new ExpressionNodeType<>() {
+		@Override
+		public Class<SkriptValueOrVariable> getReturnType() {
+			return SkriptValueOrVariable.class;
+		}
+
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of(
+				"{<token::identifier>}"
+			);
+		}
+
+		@Override
+		public @NotNull VariableExpression create(List<SyntaxNode> children) {
+			return new VariableExpression(((TokenNode) children.getFirst()).token().asString());
+		}
+	};
+
+	private final String name;
+
+	public VariableExpression(String name) {
+		this.name = name;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public @NotNull SkriptValueOrVariable resolve(@NotNull ExecuteContext context) {
+		//noinspection DataFlowIssue
+		return context.hasVariable(name) ? context.getVariable(name) : NoneValue.get();
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
@@ -33,8 +33,8 @@ public final class CommandStructure implements StructureNode {
 			return entryStructure()
 				// these strings could be tokenized the same way as syntaxes
 				.entry("trigger", "trigger:<section::command>")
-				.entry("description", "description:<token::identifier>", true)
-				.entry("prefix", "prefix:<token::identifier>", true)
+				.entry("description", "description:<token::string>", true)
+				.entry("prefix", "prefix:<token::string>", true)
 				.build();
 		}
 


### PR DESCRIPTION
### Description
This PR adds variables and changer effects, as well as some minor changes.
- `VariableExpression` - matches the variable syntax. Does not support modifiers like locality - every variable will currently be local unless an upper-level context defines one.
- `SetEffect` - matches the set effect syntax. Operates on a receiver property (Variable) to directly change the value it contains. Values themselves are not operated upon and shouldn't be.
- `IncrementEffect` - matches the incrementation syntax. Operates on a receiver property (Variable or Value) to increment it. If it's a Variable, it will use the Variable's incrementation logic. If it's a value, it will try the value's mutable increment. Additionally, increment can have `by value`, which will do the same as an AddEffect would.
- `DecrementEffect` - matches the decrementation syntax. Has the same behavior as the increment, but using decrement.
- `AddEffect` - matches the addition syntax. Operates on a receiver property (Variable or Value) to add a value to it. If it's a variable, it will use the Variable's addition logic. If it's a value, it will try the value's mutable add.
- `RemoveEffect` - matches the addition syntax. Has the same behavior as add, but using remove.
- `TypeOperationUtils` - handles the implementation of executing the above.

Also included in this PR is a slight change to the runtime to make sure a script is marked as no longer loading if it fails to load.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
