### PR TITLE
Matched Pattern feedthrough

### DIFF
--- a/skript-parser/src/main/java/org/skriptlang/skript/api/entries/StructureEntryNodeType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/entries/StructureEntryNodeType.java
@@ -21,7 +21,7 @@ public final class StructureEntryNodeType implements StatementNodeType<Structure
 	}
 
 	@Override
-	public @NotNull StructureEntryNode create(List<SyntaxNode> children) {
+	public @NotNull StructureEntryNode create(List<SyntaxNode> children, int matchedPattern) {
 		return new StructureEntryNode(name, children);
 	}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/InputNode.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/InputNode.java
@@ -37,7 +37,7 @@ public record InputNode(@NotNull String inputName) implements ExpressionNode<Var
 		}
 
 		@Override
-		public @NotNull InputNode create(List<SyntaxNode> children) {
+		public @NotNull InputNode create(List<SyntaxNode> children, int matchedPattern) {
 			return new InputNode(inputName);
 		}
 	}

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StructureNodeType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StructureNodeType.java
@@ -17,13 +17,13 @@ public abstract class StructureNodeType<T extends StructureNode> implements Stat
 	}
 
 	@Override
-	@Contract(value = "_ -> new", pure = true)
-	public final @NotNull T create(@NotNull List<SyntaxNode> children) {
+	@Contract(value = "_, _ -> new", pure = true)
+	public final @NotNull T create(@NotNull List<SyntaxNode> children, int matchedPattern) {
 		SyntaxNode last = children.getLast();
 		if (last instanceof EntryStructureSectionNode(Map<String, StructureEntryNode> entries)) {
-			return create(children, entries);
+			return create(children, matchedPattern, entries);
 		}
-		return create(children, null);
+		return create(children, matchedPattern, null);
 	}
 
 	/**
@@ -32,5 +32,5 @@ public abstract class StructureNodeType<T extends StructureNode> implements Stat
 	 * @param entries the entries in the node, if this node uses entries.
 	 * @return the new node.
 	 */
-	protected abstract @NotNull T create(@NotNull List<SyntaxNode> children, @Nullable Map<String, StructureEntryNode> entries);
+	protected abstract @NotNull T create(@NotNull List<SyntaxNode> children, int matchedPattern, @Nullable Map<String, StructureEntryNode> entries);
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/SyntaxNodeType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/SyntaxNodeType.java
@@ -18,10 +18,10 @@ public interface SyntaxNodeType<T extends SyntaxNode> {
 	 */
 	List<String> getSyntaxes();
 
-	@Contract(value = "_ -> new", pure = true)
-	@NotNull T create(List<SyntaxNode> children);
+	@Contract(value = "_, _ -> new", pure = true)
+	@NotNull T create(List<SyntaxNode> children, int matchedPattern);
 
-	default boolean canBeParsed(ParseContext context) {
+	default boolean canBeParsed(ParseContext context, int matchedPattern) {
 		return true;
 	}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/parser/TokenizedSyntax.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/parser/TokenizedSyntax.java
@@ -17,13 +17,14 @@ import java.util.*;
  * @param tokens   The tokens that make up this syntax.
  *                 This will be matched against tokenized scripts to determine if this syntax is present.
  */
-public record TokenizedSyntax(@NotNull SyntaxNodeType<?> nodeType, @NotNull List<Token> tokens) {
+public record TokenizedSyntax(@NotNull SyntaxNodeType<?> nodeType, int patternIndex, @NotNull List<Token> tokens) {
 
-	public TokenizedSyntax(@NotNull SyntaxNodeType<?> nodeType, @NotNull List<Token> tokens) {
+	public TokenizedSyntax(@NotNull SyntaxNodeType<?> nodeType, int patternIndex, @NotNull List<Token> tokens) {
 		Preconditions.checkNotNull(nodeType);
 		Preconditions.checkNotNull(tokens);
 
 		this.nodeType = nodeType;
+		this.patternIndex = patternIndex;
 		this.tokens = Collections.unmodifiableList(tokens);
 	}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/parser/pattern/SyntaxPatternElement.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/parser/pattern/SyntaxPatternElement.java
@@ -50,7 +50,7 @@ public class SyntaxPatternElement extends PatternElement {
 		return existingSyntaxes.stream().map(existingSyntax -> {
 			var newList = new LinkedList<>(existingSyntax.tokens());
 			newList.add(new Token(TokenType.SYNTAX, this, -1, 0, null));
-			return new TokenizedSyntax(nodeType, newList);
+			return new TokenizedSyntax(nodeType, existingSyntax.patternIndex(), newList);
 		}).toList();
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/parser/pattern/TokensPatternElement.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/parser/pattern/TokensPatternElement.java
@@ -33,7 +33,7 @@ public class TokensPatternElement extends PatternElement {
 			var newList = new LinkedList<Token>();
 			newList.addAll(existingSyntax.tokens());
 			newList.addAll(tokens);
-			return new TokenizedSyntax(nodeType, newList);
+			return new TokenizedSyntax(nodeType, existingSyntax.patternIndex(), newList);
 		}).toList();
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/parser/tokens/Tokenizer.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/parser/tokens/Tokenizer.java
@@ -27,9 +27,11 @@ public class Tokenizer {
 	 *
 	 * @param source A source that isn't actually a script,
 	 *               but has information pertaining to a syntax node for diagnostic convenience.
+	 * @param nodeType The node type to attach generated syntaxes to.
+	 * @param patternIndex The index of the node type's pattern that is being generated.
 	 * @return The tokenized syntax.
 	 */
-	public static ResultWithDiagnostics<List<TokenizedSyntax>> tokenizeSyntax(@NotNull ScriptSource source, @NotNull SyntaxNodeType<?> nodeType) {
+	public static ResultWithDiagnostics<List<TokenizedSyntax>> tokenizeSyntax(@NotNull ScriptSource source, @NotNull SyntaxNodeType<?> nodeType, int patternIndex) {
 		// syntax uses basic tokenization as a base
 		ResultWithDiagnostics<List<Token>> normalResult = tokenize(source);
 		if (!normalResult.isSuccess()) {
@@ -50,7 +52,7 @@ public class Tokenizer {
 
 		List<TokenizedSyntax> tokenizedSyntaxes = new LinkedList<>();
 		// initial empty syntax for elements to spin off of
-		tokenizedSyntaxes.add(new TokenizedSyntax(nodeType, Collections.emptyList()));
+		tokenizedSyntaxes.add(new TokenizedSyntax(nodeType, patternIndex, Collections.emptyList()));
 		for (PatternElement patternElement : patternElements) {
 			tokenizedSyntaxes = patternElement.createTokenizedSyntaxes(nodeType, tokenizedSyntaxes);
 		}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/base/EventStructureType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/base/EventStructureType.java
@@ -9,6 +9,7 @@ import org.skriptlang.skript.api.nodes.SyntaxNode;
 import java.util.List;
 import java.util.Map;
 
+// TODO: event base classes
 public class EventStructureType<T extends EventStructure> extends StructureNodeType<T> {
 	private final String eventSyntax;
 
@@ -24,7 +25,7 @@ public class EventStructureType<T extends EventStructure> extends StructureNodeT
 	}
 
 	@Override
-	protected @NotNull T create(@NotNull List<SyntaxNode> children, @Nullable Map<String, StructureEntryNode> entries) {
+	protected @NotNull T create(@NotNull List<SyntaxNode> children, int matchedPattern, @Nullable Map<String, StructureEntryNode> entries) {
 		return null;
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/AddEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/AddEffect.java
@@ -17,16 +17,17 @@ public class AddEffect implements EffectNode {
 		@Override
 		public List<String> getSyntaxes() {
 			return List.of(
-				"(add|give) <expr> to <expr>"
+				"(add|give) <expr> to <expr>",
+				"give <expr> <expr>"
 			);
 		}
 
 		@Override
-		public @NotNull AddEffect create(@NotNull List<SyntaxNode> children) {
-			return new AddEffect(
-				(ExpressionNode<?>) children.get(0),
-				(ExpressionNode<?>) children.get(1)
-			);
+		public @NotNull AddEffect create(@NotNull List<SyntaxNode> children, int matchedPattern) {
+			ExpressionNode<?> receiver = matchedPattern == 0 ? (ExpressionNode<?>) children.get(1) : (ExpressionNode<?>) children.get(0);
+			ExpressionNode<?> value = matchedPattern == 0 ? (ExpressionNode<?>) children.get(0) : (ExpressionNode<?>) children.get(1);
+
+			return new AddEffect(value, receiver);
 		}
 	};
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/BroadcastEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/BroadcastEffect.java
@@ -18,7 +18,7 @@ public class BroadcastEffect implements EffectNode {
 		}
 
 		@Override
-		public @NotNull BroadcastEffect create(List<SyntaxNode> children) {
+		public @NotNull BroadcastEffect create(List<SyntaxNode> children, int matchedPattern) {
 			return new BroadcastEffect((ExpressionNode<?>) children.getFirst());
 		}
 	};

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/DecrementEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/DecrementEffect.java
@@ -21,7 +21,7 @@ public class DecrementEffect implements EffectNode {
 		}
 
 		@Override
-		public @NotNull DecrementEffect create(List<SyntaxNode> children) {
+		public @NotNull DecrementEffect create(List<SyntaxNode> children, int matchedPattern) {
 			ExpressionNode<?> amountSelector = children.size() == 2 ? (ExpressionNode<?>) children.get(1) : null;
 			return new DecrementEffect((ExpressionNode<?>) children.getFirst(), amountSelector);
 		}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/IncrementEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/IncrementEffect.java
@@ -24,7 +24,7 @@ public class IncrementEffect implements EffectNode {
 		}
 
 		@Override
-		public @NotNull IncrementEffect create(List<SyntaxNode> children) {
+		public @NotNull IncrementEffect create(List<SyntaxNode> children, int matchedPattern) {
 			ExpressionNode<?> amountSelector = children.size() == 2 ? (ExpressionNode<?>) children.get(1) : null;
 			return new IncrementEffect((ExpressionNode<?>) children.getFirst(), amountSelector);
 		}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/RemoveEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/RemoveEffect.java
@@ -20,7 +20,7 @@ public class RemoveEffect implements EffectNode {
 		}
 
 		@Override
-		public @NotNull RemoveEffect create(@NotNull List<SyntaxNode> children) {
+		public @NotNull RemoveEffect create(@NotNull List<SyntaxNode> children, int matchedPattern) {
 			return new RemoveEffect(
 				(ExpressionNode<?>) children.get(0),
 				(ExpressionNode<?>) children.get(1)

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/SetEffect.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/effects/SetEffect.java
@@ -13,14 +13,14 @@ import org.skriptlang.skript.stdlib.syntax.expressions.VariableExpression;
 import java.util.List;
 
 public class SetEffect implements EffectNode {
-	public static final EffectNodeType<SetEffect> TYPE = new EffectNodeType<SetEffect>() {
+	public static final EffectNodeType<SetEffect> TYPE = new EffectNodeType<>() {
 		@Override
 		public List<String> getSyntaxes() {
 			return List.of("set <expr> to <expr>");
 		}
 
 		@Override
-		public @NotNull SetEffect create(List<SyntaxNode> children) {
+		public @NotNull SetEffect create(List<SyntaxNode> children, int matchedPattern) {
 			return new SetEffect((ExpressionNode<?>) children.getFirst(), (ExpressionNode<?>) children.get(1));
 		}
 	};

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/NumberLiteralExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/NumberLiteralExpression.java
@@ -23,7 +23,7 @@ public class NumberLiteralExpression implements ExpressionNode<NumberValue> {
 		}
 
 		@Override
-		public @NotNull NumberLiteralExpression create(List<SyntaxNode> children) {
+		public @NotNull NumberLiteralExpression create(List<SyntaxNode> children, int matchedPattern) {
 			return new NumberLiteralExpression(new NumberValue(Double.parseDouble(((TokenNode) children.getFirst()).token().asString())));
 		}
 	};

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/PropertyExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/PropertyExpression.java
@@ -28,7 +28,7 @@ public final class PropertyExpression implements ExpressionNode<Variable.OfPrope
 		}
 
 		@Override
-		public @NotNull PropertyExpression create(List<SyntaxNode> children) {
+		public @NotNull PropertyExpression create(List<SyntaxNode> children, int matchedPattern) {
 			return new PropertyExpression(((TokenNode) children.getFirst()).token().asString(), (ExpressionNode<?>) children.get(1));
 		}
 	};
@@ -52,7 +52,13 @@ public final class PropertyExpression implements ExpressionNode<Variable.OfPrope
 			receiver = variable.get();
 		}
 
+		// TODO: need a way to feed an ExecuteResult out of an expression
+		if (receiver == null) throw new IllegalStateException("Cannot get property of a non-variable");
 		SkriptProperty<?, ?> prop = receiver.getType(context.runtime()).getProperty(propertyName);
+		if (prop == null) {
+			// TODO: SkriptValueType should have a type name
+			throw new IllegalStateException("Property '" + propertyName + "' does not exist on type '" + receiver.getType(context.runtime()) + "'");
+		}
 		return prop.asVariable(receiver);
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/StringLiteralExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/StringLiteralExpression.java
@@ -23,7 +23,7 @@ public class StringLiteralExpression implements ExpressionNode<StringValue> {
 		}
 
 		@Override
-		public @NotNull StringLiteralExpression create(List<SyntaxNode> children) {
+		public @NotNull StringLiteralExpression create(List<SyntaxNode> children, int matchedPattern) {
 			return new StringLiteralExpression(new StringValue(((TokenNode) children.getFirst()).token().asString()));
 		}
 	};

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/VariableExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/VariableExpression.java
@@ -26,7 +26,7 @@ public class VariableExpression implements ExpressionNode<SkriptValueOrVariable>
 		}
 
 		@Override
-		public @NotNull VariableExpression create(List<SyntaxNode> children) {
+		public @NotNull VariableExpression create(List<SyntaxNode> children, int matchedPattern) {
 			return new VariableExpression(((TokenNode) children.getFirst()).token().asString());
 		}
 	};

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
@@ -39,7 +39,7 @@ public final class CommandStructure implements StructureNode {
 		}
 
 		@Override
-		protected @NotNull CommandStructure create(@NotNull List<SyntaxNode> children, @Nullable Map<String, StructureEntryNode> entries) {
+		protected @NotNull CommandStructure create(@NotNull List<SyntaxNode> children, int matchedPattern, @Nullable Map<String, StructureEntryNode> entries) {
 			Preconditions.checkNotNull(entries, "Commands contractually expect entries");
 
 			String name = ((TokenNode) children.getFirst()).token().asString();

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/FunctionStructure.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/FunctionStructure.java
@@ -21,7 +21,7 @@ public class FunctionStructure implements StructureNode {
 		}
 
 		@Override
-		public @NotNull FunctionStructure create(List<SyntaxNode> children, @Nullable Map<String, StructureEntryNode> entries) {
+		public @NotNull FunctionStructure create(List<SyntaxNode> children, int matchedPattern, @Nullable Map<String, StructureEntryNode> entries) {
 			List<SyntaxNode> tokenNodesInParams = children.subList(1, children.size() - 2);
 			// TODO: params
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/OnScriptLoadEvent.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/OnScriptLoadEvent.java
@@ -32,7 +32,7 @@ public class OnScriptLoadEvent implements StructureNode {
 		}
 
 		@Override
-		public @NotNull OnScriptLoadEvent create(List<SyntaxNode> children, @Nullable Map<String, StructureEntryNode> entries) {
+		public @NotNull OnScriptLoadEvent create(List<SyntaxNode> children, int matchedPattern, @Nullable Map<String, StructureEntryNode> entries) {
 			return new OnScriptLoadEvent((SectionNode) children.getFirst());
 		}
 	};


### PR DESCRIPTION
### Description
This PR fixed #7 by feeding the pattern's original index through tokenization.
An example of correctly working behavior is shown in `AddEffect`.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** #7 <!-- Links to related issues -->
