### PR TITLE
Add type names to the SkriptValueTypes

### DIFF
--- a/skript-parser/src/main/java/org/skriptlang/skript/api/runtime/SkriptRuntime.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/runtime/SkriptRuntime.java
@@ -40,6 +40,13 @@ public interface SkriptRuntime {
 	<T extends SkriptValue> @Nullable SkriptValueType<T> getTypeByClass(@NotNull Class<T> clazz);
 
 	/**
+	 * Resolves the name of a type using the runtime's type storage.
+	 * @param type the type to resolve the name of
+	 * @return the name of the type
+	 */
+    @NotNull String getNameOfType(@NotNull SkriptValueType<?> type);
+
+    /**
 	 * Adds a type to the runtime. This method is only available before the runtime is locked.
 	 * @param type the type to add
 	 * @return the constructed type

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptValueType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/SkriptValueType.java
@@ -27,6 +27,10 @@ public interface SkriptValueType<T extends SkriptValue> {
 	 */
 	@Nullable SkriptValueType<?> superType();
 
+	default @NotNull String name() {
+		return runtime().getNameOfType(this);
+	}
+
 	/**
 	 * Check if the value is an instance of this type.
 	 * <p>

--- a/skript-parser/src/main/java/org/skriptlang/skript/runtime/SkriptRuntimeImpl.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/runtime/SkriptRuntimeImpl.java
@@ -51,6 +51,15 @@ public class SkriptRuntimeImpl implements SkriptRuntime {
 	}
 
 	@Override
+	public @NotNull String getNameOfType(@NotNull SkriptValueType<?> type) {
+		return typesByName.entrySet().stream()
+			.filter(entry -> entry.getValue() == type)
+			.findFirst()
+			.orElseThrow()
+			.getKey();
+	}
+
+	@Override
 	public <T extends SkriptValue> @NotNull SkriptValueType<T> addType(@NotNull StagedSkriptValueType<T> type) {
 		if (lockAccess.isLocked()) throw new IllegalStateException("Cannot add type after runtime is locked");
 		if (typesByName.containsKey(type.typeName())) throw new IllegalArgumentException("Type with name " + type.typeName() + " already exists");

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/PropertyExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/PropertyExpression.java
@@ -6,10 +6,7 @@ import org.skriptlang.skript.api.nodes.ExpressionNodeType;
 import org.skriptlang.skript.api.nodes.SyntaxNode;
 import org.skriptlang.skript.api.nodes.TokenNode;
 import org.skriptlang.skript.api.runtime.ExecuteContext;
-import org.skriptlang.skript.api.types.SkriptProperty;
-import org.skriptlang.skript.api.types.SkriptValue;
-import org.skriptlang.skript.api.types.SkriptValueOrVariable;
-import org.skriptlang.skript.api.types.Variable;
+import org.skriptlang.skript.api.types.*;
 
 import java.util.List;
 
@@ -54,10 +51,13 @@ public final class PropertyExpression implements ExpressionNode<Variable.OfPrope
 
 		// TODO: need a way to feed an ExecuteResult out of an expression
 		if (receiver == null) throw new IllegalStateException("Cannot get property of a non-variable");
-		SkriptProperty<?, ?> prop = receiver.getType(context.runtime()).getProperty(propertyName);
+
+		SkriptValueType<?> type = receiver.getType(context.runtime());
+
+		SkriptProperty<?, ?> prop = type.getProperty(propertyName);
 		if (prop == null) {
 			// TODO: SkriptValueType should have a type name
-			throw new IllegalStateException("Property '" + propertyName + "' does not exist on type '" + receiver.getType(context.runtime()) + "'");
+			throw new IllegalStateException("Property '" + propertyName + "' does not exist on type '" + type.name() + "'");
 		}
 		return prop.asVariable(receiver);
 	}


### PR DESCRIPTION
### Description
This PR adds the type name to SkriptValueType, which uses the runtime's type information.

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
