### PR TITLE
Rework parser to better parse expressions

### DIFF
--- a/skript-parser/src/main/java/org/skriptlang/skript/api/entries/StructureSectionNode.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/entries/StructureSectionNode.java
@@ -5,8 +5,8 @@ import org.skriptlang.skript.api.nodes.SyntaxNode;
 
 import java.util.Map;
 
-public record EntryStructureSectionNode(Map<String, StructureEntryNode> entries) implements SyntaxNode {
-	public EntryStructureSectionNode(Map<String, StructureEntryNode> entries) {
+public record StructureSectionNode(Map<String, StructureEntryNode> entries) implements SyntaxNode {
+	public StructureSectionNode(Map<String, StructureEntryNode> entries) {
 		this.entries = ImmutableMap.copyOf(entries);
 	}
 

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StringNode.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StringNode.java
@@ -1,0 +1,28 @@
+package org.skriptlang.skript.api.nodes;
+
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.StringValue;
+
+import java.util.List;
+
+public class StringNode implements ExpressionNode<StringValue> {
+	private final String base;
+	private final List<ExpressionNode<?>> childrenSelectors;
+
+	public StringNode(String base, List<ExpressionNode<?>> children) {
+		this.base = base.startsWith("\"") && base.endsWith("\"") ? base.substring(1, base.length() - 1) : base;
+		this.childrenSelectors = ImmutableList.copyOf(children);
+	}
+
+	@Override
+	public @NotNull StringValue resolve(@NotNull ExecuteContext context) {
+		Object[] stringifiedChildren = childrenSelectors.stream()
+			.map(it -> it.resolve(context).toValue().toString())
+			.toArray(String[]::new);
+
+		return new StringValue(String.format(base.replace("\\%", "%%"), stringifiedChildren));
+
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StructureNodeType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/StructureNodeType.java
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.skriptlang.skript.api.entries.EntryStructureDefinition;
 import org.skriptlang.skript.api.entries.StructureEntryNode;
-import org.skriptlang.skript.api.entries.EntryStructureSectionNode;
+import org.skriptlang.skript.api.entries.StructureSectionNode;
 
 import java.util.List;
 import java.util.Map;
@@ -20,7 +20,7 @@ public abstract class StructureNodeType<T extends StructureNode> implements Stat
 	@Contract(value = "_, _ -> new", pure = true)
 	public final @NotNull T create(@NotNull List<SyntaxNode> children, int matchedPattern) {
 		SyntaxNode last = children.getLast();
-		if (last instanceof EntryStructureSectionNode(Map<String, StructureEntryNode> entries)) {
+		if (last instanceof StructureSectionNode(Map<String, StructureEntryNode> entries)) {
 			return create(children, matchedPattern, entries);
 		}
 		return create(children, matchedPattern, null);

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/SyntaxNodeType.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/nodes/SyntaxNodeType.java
@@ -21,6 +21,13 @@ public interface SyntaxNodeType<T extends SyntaxNode> {
 	@Contract(value = "_, _ -> new", pure = true)
 	@NotNull T create(List<SyntaxNode> children, int matchedPattern);
 
+	/**
+	 * Whether this node type can be parsed in the current context.
+	 * This must be deterministic.
+	 * @param context The current parsing context.
+	 * @param matchedPattern The index of the syntax pattern that was matched.
+	 * @return Whether this node type can be parsed.
+	 */
 	default boolean canBeParsed(ParseContext context, int matchedPattern) {
 		return true;
 	}

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/ListValue.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/ListValue.java
@@ -3,6 +3,7 @@ package org.skriptlang.skript.api.types;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -54,5 +55,26 @@ public class ListValue extends IterableValue {
 	@Override
 	public @NotNull Iterator<SkriptValue> iterator() {
 		return value.iterator();
+	}
+
+	/**
+	 * Note the return type is a view.
+	 */
+	public List<SkriptValue> jvmValue() {
+		return Collections.unmodifiableList(value);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder().append('[');
+		int size = value.size();
+		if (size > 0) builder.append(value.getFirst());
+		else return "[]";
+		for (int i = 1; i < size - 1; i++) {
+			builder.append(", ").append(value.get(i));
+		}
+		if (size > 2) builder.append(",");
+		builder.append(" and ").append(value.getLast());
+		return builder.append(']').toString();
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/api/types/ScriptInfoValue.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/api/types/ScriptInfoValue.java
@@ -11,19 +11,28 @@ public final class ScriptInfoValue extends SkriptValue {
 		.property("name", skriptProperty(ScriptInfoValue.class, StringValue.class)
 			.getter(ScriptInfoValue::name)
 		)
+		.property("length", skriptProperty(ScriptInfoValue.class, NumberValue.class)
+			.getter(ScriptInfoValue::sourceLength)
+		)
 		.build();
 
 	private final StringValue name;
+	private final NumberValue sourceLength;
 
-	public ScriptInfoValue(StringValue name) {
+	public ScriptInfoValue(StringValue name, NumberValue sourceLength) {
 		this.name = name;
+		this.sourceLength = sourceLength;
 	}
 
 	public StringValue name() {
 		return name;
 	}
 
+	public NumberValue sourceLength() {
+		return sourceLength;
+	}
+
 	public static ScriptInfoValue ofSource(@NotNull Script source) {
-		return new ScriptInfoValue(new StringValue(source.source().name()));
+		return new ScriptInfoValue(new StringValue(source.source().name()), new NumberValue(source.source().content().length()));
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/parser/tokens/Token.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/parser/tokens/Token.java
@@ -22,7 +22,7 @@ public record Token(
 	@NotNull Object value,
 	int start,
 	int length,
-	@Nullable List<Token> children
+	@Nullable List<List<Token>> children
 ) {
 
 	/**

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/SyntaxManifest.java
@@ -2,10 +2,7 @@ package org.skriptlang.skript.stdlib;
 
 import org.skriptlang.skript.api.SkriptParser;
 import org.skriptlang.skript.stdlib.syntax.effects.*;
-import org.skriptlang.skript.stdlib.syntax.expressions.NumberLiteralExpression;
-import org.skriptlang.skript.stdlib.syntax.expressions.PropertyExpression;
-import org.skriptlang.skript.stdlib.syntax.expressions.StringLiteralExpression;
-import org.skriptlang.skript.stdlib.syntax.expressions.VariableExpression;
+import org.skriptlang.skript.stdlib.syntax.expressions.*;
 import org.skriptlang.skript.stdlib.syntax.structures.CommandStructure;
 import org.skriptlang.skript.stdlib.syntax.structures.OnScriptLoadEvent;
 
@@ -29,6 +26,7 @@ public final class SyntaxManifest {
 		parser.submitNode(DecrementEffect.TYPE);
 		parser.submitNode(AddEffect.TYPE);
 		parser.submitNode(RemoveEffect.TYPE);
+		parser.submitNode(ListExpression.TYPE);
 	}
 
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/ListExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/ListExpression.java
@@ -1,0 +1,68 @@
+package org.skriptlang.skript.stdlib.syntax.expressions;
+
+import org.jetbrains.annotations.NotNull;
+import org.skriptlang.skript.api.nodes.ExpressionNode;
+import org.skriptlang.skript.api.nodes.ExpressionNodeType;
+import org.skriptlang.skript.api.nodes.SyntaxNode;
+import org.skriptlang.skript.api.runtime.ExecuteContext;
+import org.skriptlang.skript.api.types.ListValue;
+import org.skriptlang.skript.api.types.SkriptValue;
+import org.skriptlang.skript.api.types.SkriptValueOrVariable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ListExpression implements ExpressionNode<ListValue> {
+	public static final ExpressionNodeType<ListExpression, ListValue> TYPE = new ExpressionNodeType<>() {
+		@Override
+		public Class<ListValue> getReturnType() {
+			return ListValue.class;
+		}
+
+		@Override
+		public List<String> getSyntaxes() {
+			return List.of(
+				"<expr>(,|[,] and) <expr>"
+			);
+		}
+
+		@Override
+		public @NotNull ListExpression create(List<SyntaxNode> children, int matchedPattern) {
+			ExpressionNode<?> first = (ExpressionNode<?>) children.get(0);
+			ExpressionNode<?> second = (ExpressionNode<?>) children.get(1);
+			return new ListExpression(first, second);
+		}
+	};
+
+	private final ExpressionNode<?> firstSelector;
+	private final ExpressionNode<?> secondSelector;
+
+	public ListExpression(ExpressionNode<?> firstSelector, ExpressionNode<?> secondSelector) {
+		this.firstSelector = firstSelector;
+		this.secondSelector = secondSelector;
+	}
+
+	@Override
+	public @NotNull ListValue resolve(@NotNull ExecuteContext context) {
+		SkriptValueOrVariable firstOrVar = firstSelector.resolve(context);
+		SkriptValueOrVariable secondOrVar = secondSelector.resolve(context);
+
+		List<SkriptValue> values = new LinkedList<>();
+
+		values.add(firstOrVar.toValue());
+
+		if (secondSelector instanceof ListExpression) {
+			values.addAll(((ListValue) secondOrVar.toValue()).jvmValue());
+		} else {
+			values.add(secondOrVar.toValue());
+		}
+
+
+		ListValue list = new ListValue();
+		for (SkriptValue value : values) {
+			list.addDirectly(value);
+		}
+
+		return list;
+	}
+}

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/StringLiteralExpression.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/expressions/StringLiteralExpression.java
@@ -1,10 +1,7 @@
 package org.skriptlang.skript.stdlib.syntax.expressions;
 
 import org.jetbrains.annotations.NotNull;
-import org.skriptlang.skript.api.nodes.ExpressionNode;
-import org.skriptlang.skript.api.nodes.ExpressionNodeType;
-import org.skriptlang.skript.api.nodes.SyntaxNode;
-import org.skriptlang.skript.api.nodes.TokenNode;
+import org.skriptlang.skript.api.nodes.*;
 import org.skriptlang.skript.api.runtime.ExecuteContext;
 import org.skriptlang.skript.api.types.StringValue;
 
@@ -24,18 +21,18 @@ public class StringLiteralExpression implements ExpressionNode<StringValue> {
 
 		@Override
 		public @NotNull StringLiteralExpression create(List<SyntaxNode> children, int matchedPattern) {
-			return new StringLiteralExpression(new StringValue(((TokenNode) children.getFirst()).token().asString()));
+			return new StringLiteralExpression((StringNode) children.getFirst());
 		}
 	};
 
-	private final StringValue value;
+	private final ExpressionNode<?> stringTokenSelector;
 
-	public StringLiteralExpression(StringValue value) {
-		this.value = value;
+	public StringLiteralExpression(ExpressionNode<?> stringTokenSelector) {
+		this.stringTokenSelector = stringTokenSelector;
 	}
 
 	@Override
 	public @NotNull StringValue resolve(@NotNull ExecuteContext context) {
-		return value;
+		return (StringValue) stringTokenSelector.resolve(context).toValue();
 	}
 }

--- a/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
+++ b/skript-parser/src/main/java/org/skriptlang/skript/stdlib/syntax/structures/CommandStructure.java
@@ -51,26 +51,26 @@ public final class CommandStructure implements StructureNode {
 			SectionNode triggerSection = (SectionNode) trigger.children().getFirst();
 
 			StructureEntryNode descriptionNode = entries.get("description");
-			TokenNode description = descriptionNode == null ? null : (TokenNode) descriptionNode.children().getFirst();
+			StringNode description = descriptionNode == null ? null : (StringNode) descriptionNode.children().getFirst();
 
 			StructureEntryNode prefixNode = entries.get("prefix");
-			TokenNode prefix = prefixNode == null ? null : (TokenNode) prefixNode.children().getFirst();
+			StringNode prefix = prefixNode == null ? null : (StringNode) prefixNode.children().getFirst();
 
 			return new CommandStructure(
 				name,
 				triggerSection,
-				description != null ? description.token().asString() : "",
-				prefix != null ? prefix.token().asString() : null
+				description,
+				prefix
 			);
 		}
 	};
 
 	private final @NotNull String name;
 	private final SectionNode trigger;
-	private final @NotNull String description;
-	private final @Nullable String prefix;
+	private final @NotNull StringNode description;
+	private final @Nullable StringNode prefix;
 
-	public CommandStructure(@NotNull String name, SectionNode trigger, @NotNull String description, @Nullable String prefix) {
+	public CommandStructure(@NotNull String name, SectionNode trigger, @NotNull StringNode description, @Nullable StringNode prefix) {
 		this.name = name;
 		this.trigger = trigger;
 		this.description = description;


### PR DESCRIPTION
### Description
This PR reworks a lot of the internals in the parser implementation to parse expressions better and closer to how current Skript does. Rather than match the biggest expression child possible, candidates will now look for their next literal tokens and use that.
There are still edge cases with the current implementation. For example, Subsequent places where an expression could end will never be tried. This means that the first occurrence of the candidate's next literals are the *only* place they can be.
That being said, parenthesis around expressions is now supported, and will resolve that issue for the time being.

Moves closer to solving #4 
Fixes #11 
Fixes #12 

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
